### PR TITLE
Redirect fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=../../doc/html/type_index.html">
+<meta http-equiv="refresh" content="0; url=../../doc/html/boost_typeindex.html">
 <title>Boost.TypeIndex</title>
 <style>
   body {
@@ -26,7 +26,7 @@
 <body>
   <p>
     Automatic redirection failed, please go to
-    <a href="../../doc/html/type_index.html">../../doc/html/type_index.html</a>
+    <a href="../../doc/html/boost_typeindex.html">../../doc/html/boost_typeindex.html</a>
   </p>
   <p>
     &copy; 2014 Antony Polukhin


### PR DESCRIPTION
The documentation is at:

http://www.boost.org/doc/libs/develop/doc/html/boost_typeindex.html

The filename is generated from the title of the quickbook documentation, alternatively you might prefer to specify the name explicitly using the 'id' attribute, which can be better if you ever change the title:

```
[library Boost.TypeIndex
    [quickbook 1.6]
    [id type_index]
    [version 4.0]
    [copyright 2012-2014 Antony Polukhin]
    [category Language Features Emulation]
    [license
        Distributed under the Boost Software License, Version 1.0.
        (See accompanying file LICENSE_1_0.txt or copy at
        [@http://www.boost.org/LICENSE_1_0.txt])
    ]
]
```
