### PR TITLE
Allow BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY for MSVC

### DIFF
--- a/include/boost/type_index.hpp
+++ b/include/boost/type_index.hpp
@@ -27,7 +27,7 @@
 #   endif
 #elif (!defined(BOOST_NO_RTTI) && !defined(BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY)) || defined(BOOST_MSVC)
 #   include <boost/type_index/stl_type_index.hpp>
-#   ifdef BOOST_NO_RTTI
+#   if defined(BOOST_NO_RTTI) || defined(BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY)
 #       include <boost/type_index/detail/stl_register_class.hpp>
 #       ifdef BOOST_HAS_PRAGMA_DETECT_MISMATCH
 #           pragma detect_mismatch( "boost__type_index__abi", "RTTI is off - typeid() is used only for templates")


### PR DESCRIPTION
BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY had no effect for MSVC. With this change, it is treated like BOOST_NO_RTTI also for MSVC.
