### PR TITLE
Support Clang version 4.0.

### DIFF
--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -55,7 +55,7 @@
     // sizeof("static const char *boost::detail::ctti<") - 1, sizeof(">::n()") - 1
     // note: checked on 3.0
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(39, 6, false, "")
-#elif defined(__clang__) && __clang_major__ == 3 && __clang_minor__ > 0
+#elif defined(__clang__) && (__clang_major__ >= 4 || (__clang_major__ == 3 && __clang_minor__ > 0))
     // sizeof("static const char *boost::detail::ctti<") - 1, sizeof("]") - 1, true, "int>::n() [T = int"
     // note: checked on 3.1, 3.4
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(39, 1, true, "T = ")


### PR DESCRIPTION
Currently the configuration logic assumes that Clang's major version is no more than 3. This patch adds support for Clang 4.0.

I think the change is self-explanatory. Let me know if I can provide more information.