### PR TITLE
Add support for GCC built for AVR targets

### DIFF
--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -59,9 +59,12 @@
     // sizeof("static const char *boost::detail::ctti<") - 1, sizeof("]") - 1, true, "int>::n() [T = int"
     // note: checked on 3.1, 3.4
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(39, 1, true, "T = ")
-#elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR)
-    // sizeof("static contexpr char boost::detail::ctti<T>::s() [with long unsigned int I = 0ul; T = ") - 1, sizeof("]") - 1
+#elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR) && !defined(__AVR__)
+    // sizeof("static constexpr char boost::detail::ctti<T>::s() [with long unsigned int I = 0ul; T = ") - 1, sizeof("]") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(87, 1, false, "")
+#elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR) && defined(__AVR__)
+    // sizeof("static constexpr char boost::detail::ctti<T>::s() [with unsigned int I = 0u; T = ") - 1, sizeof("]")-1
+    BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(81, 1, false, "")
 #elif defined(__GNUC__) && defined(BOOST_NO_CXX14_CONSTEXPR)
     // sizeof("static const char* boost::detail::ctti<T>::n() [with T = ") - 1, sizeof("]") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(57, 1, false, "")


### PR DESCRIPTION
This includes a special case for type_index library for AVR targets
which use unsigned int as std::size_t type.