### PR TITLE
Include <boost/functional/hash.hpp> if required

### DIFF
--- a/examples/registry.cpp
+++ b/examples/registry.cpp
@@ -12,7 +12,6 @@
 
 #include <boost/type_index.hpp>
 #include <boost/unordered_set.hpp>
-#include <boost/functional/hash.hpp>
 //<-
 // Making `#include <cassert>` visible in docs, while actually using `BOOST_TEST`
 // instead of `assert`. This is required to verify correct behavior even if NDEBUG

--- a/examples/user_defined_typeinfo.hpp
+++ b/examples/user_defined_typeinfo.hpp
@@ -70,7 +70,15 @@ namespace my_namespace { namespace detail {
     `my_type_index` is a user created type_index class. If in doubt during this phase, you can always
     take a look at the `<boost/type_index/ctti_type_index.hpp>` or `<boost/type_index/stl_type_index.hpp>`
     files. Documentation for `type_index_facade` could be also useful.
+*/
 
+/*`
+    Since we are not going to override `type_index_facade::hash_code()` we must additionally include
+    `<boost/functional/hash.hpp>`.
+*/
+#include <boost/functional/hash.hpp>
+
+/*`
     See implementation of `my_type_index`:
 */
 namespace my_namespace {

--- a/include/boost/type_index/ctti_type_index.hpp
+++ b/include/boost/type_index/ctti_type_index.hpp
@@ -22,6 +22,7 @@
 #include <boost/type_index/detail/compile_time_type_info.hpp>
 
 #include <cstring>
+#include <boost/functional/hash.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/remove_cv.hpp>
 #include <boost/type_traits/remove_reference.hpp>

--- a/include/boost/type_index/stl_type_index.hpp
+++ b/include/boost/type_index/stl_type_index.hpp
@@ -40,6 +40,10 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/or.hpp>
 
+#if !(_MSC_VER > 1600 || (__GNUC__ == 4 && __GNUC_MINOR__ > 5 && defined(__GXX_EXPERIMENTAL_CXX0X__)))
+#   include <boost/functional/hash/hash.hpp>
+#endif
+
 #if (defined(__EDG_VERSION__) && __EDG_VERSION__ < 245) \
         || (defined(__sgi) && defined(_COMPILER_VERSION) && _COMPILER_VERSION <= 744)
 #   include <boost/type_traits/is_signed.hpp>

--- a/include/boost/type_index/stl_type_index.hpp
+++ b/include/boost/type_index/stl_type_index.hpp
@@ -40,7 +40,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/or.hpp>
 
-#if !(_MSC_VER > 1600 || (__GNUC__ == 4 && __GNUC_MINOR__ > 5 && defined(__GXX_EXPERIMENTAL_CXX0X__)))
+#if !((defined(_MSC_VER) && _MSC_VER > 1600) || (__GNUC__ == 4 && __GNUC_MINOR__ > 5 && defined(__GXX_EXPERIMENTAL_CXX0X__)))
 #   include <boost/functional/hash/hash.hpp>
 #endif
 

--- a/include/boost/type_index/stl_type_index.hpp
+++ b/include/boost/type_index/stl_type_index.hpp
@@ -41,7 +41,7 @@
 #include <boost/mpl/or.hpp>
 
 #if !((defined(_MSC_VER) && _MSC_VER > 1600) || (__GNUC__ == 4 && __GNUC_MINOR__ > 5 && defined(__GXX_EXPERIMENTAL_CXX0X__)))
-#   include <boost/functional/hash/hash.hpp>
+#   include <boost/functional/hash.hpp>
 #endif
 
 #if (defined(__EDG_VERSION__) && __EDG_VERSION__ < 245) \

--- a/include/boost/type_index/type_index_facade.hpp
+++ b/include/boost/type_index/type_index_facade.hpp
@@ -103,7 +103,8 @@ public:
 
     /// \b Override: This function \b may be redefined in Derived class. Overrides \b must not throw.
     /// \return Hash code of a type. By default hashes types by raw_name().
-    /// \note <boost/functional/hash.hpp> has to be included if this function is used.
+    /// \note Derived class header \b must include <boost/functional/hash.hpp>, \b unless this function is redefined in
+    /// Derived class to not use boost::hash_range().
     inline std::size_t hash_code() const BOOST_NOEXCEPT {
         const char* const name_raw = derived().raw_name();
         return boost::hash_range(name_raw, name_raw + std::strlen(name_raw));

--- a/test/type_index_constexpr_test.cpp
+++ b/test/type_index_constexpr_test.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/type_index/ctti_type_index.hpp>
 
-#include <boost/functional/hash.hpp>
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <string>

--- a/test/type_index_test.cpp
+++ b/test/type_index_test.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/type_index.hpp>
 
-#include <boost/functional/hash.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <boost/core/lightweight_test.hpp>


### PR DESCRIPTION
With gcc 6.3.0, the following program fails to link:
```
#include <boost/type_index.hpp>
int main() {
    return boost::typeindex::type_id<int>().hash_code();
}
In function `main':
main.cpp:(.text.startup+0x23): undefined reference to `unsigned long boost::hash_range<char const*>(char const*, char const*)'
collect2: error: ld returned 1 exit status
```
Example: http://coliru.stacked-crooked.com/a/0b04de325c6f6529

Workaround is to `#include <boost/functional/hash.hpp>` before/after including Boost.TypeIndex headers.
