### PR TITLE
fix ctti_type_index for GCC 7

### DIFF
--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -11,7 +11,7 @@
 
 /// \file compile_time_type_info.hpp
 /// \brief Contains helper macros and implementation details of boost::typeindex::ctti_type_index.
-/// Not intended for inclusion from user's code. 
+/// Not intended for inclusion from user's code.
 
 #include <boost/config.hpp>
 #include <boost/static_assert.hpp>
@@ -59,9 +59,12 @@
     // sizeof("static const char *boost::detail::ctti<") - 1, sizeof("]") - 1, true, "int>::n() [T = int"
     // note: checked on 3.1, 3.4
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(39, 1, true, "T = ")
-#elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR)
-    // sizeof("static contexpr char boost::detail::ctti<T>::s() [with unsigned int I = 0u; T = ") - 1, sizeof("]") - 1
+#elif defined(__GNUC__) && (__GNUC__ < 7) && !defined(BOOST_NO_CXX14_CONSTEXPR)
+    // sizeof("static constexpr char boost::detail::ctti<T>::s() [with unsigned int I = 0u; T = ") - 1, sizeof("]") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(81, 1, false, "")
+#elif defined(__GNUC__) && (__GNUC__ >= 7) && !defined(BOOST_NO_CXX14_CONSTEXPR)
+    // sizeof("static constexpr char boost::detail::ctti<T>::s() [with unsigned int I = 0; T = ") - 1, sizeof("]") - 1
+    BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(80, 1, false, "")
 #elif defined(__GNUC__) && defined(BOOST_NO_CXX14_CONSTEXPR)
     // sizeof("static const char* boost::detail::ctti<T>::n() [with T = ") - 1, sizeof("]") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(57, 1, false, "")
@@ -72,7 +75,7 @@
 
 #undef BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS
 
-namespace boost { namespace typeindex { namespace detail { 
+namespace boost { namespace typeindex { namespace detail {
     template <bool Condition>
     BOOST_CXX14_CONSTEXPR inline void assert_compile_time_legths() BOOST_NOEXCEPT {
         BOOST_STATIC_ASSERT_MSG(
@@ -149,7 +152,7 @@ namespace boost { namespace typeindex { namespace detail {
     BOOST_CXX14_CONSTEXPR inline const char* skip_begining(const char* begin) BOOST_NOEXCEPT {
         assert_compile_time_legths<(ArrayLength > ctti_skip_size_at_begin + ctti_skip_size_at_end)>();
         return skip_begining_runtime<ArrayLength - ctti_skip_size_at_begin>(
-            begin + ctti_skip_size_at_begin, 
+            begin + ctti_skip_size_at_begin,
             boost::mpl::bool_<ctti_skip_more_at_runtime>()
         );
     }
@@ -203,7 +206,7 @@ namespace boost { namespace detail {
 /// This name must be as short as possible, to avoid code bloat
 template <class T>
 struct ctti {
-   
+
 #if !defined(__clang__) && defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR)
     //helper functions
     template <unsigned int I>
@@ -286,4 +289,3 @@ struct ctti {
 }} // namespace boost::detail
 
 #endif // BOOST_TYPE_INDEX_DETAIL_COMPILE_TIME_TYPE_INFO_HPP
-


### PR DESCRIPTION
`__PRETTY_FUNCTION__` is slightly different in GCC 7.

The output of an unsigned int literal doesn't contain the 'u' anymore.

```
#include <iostream>

template < typename T >
struct ctti{
    template < unsigned int D = 1 >
    static constexpr auto name()noexcept{
        return __PRETTY_FUNCTION__;
    }
};

int main(){
    using ctti = ctti< int >;
    std::cout << ctti::name() << '\n';
}
```
