### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/type_index
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,26 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/type_index
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/container_hash//boost_container_hash
+        <source>/boost/core//boost_core
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_type_index ]
+    [ alias all : boost_type_index test ]
+    ;
+
+call-if : boost-library type_index
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/type_index

--- a/build.jam
+++ b/build.jam
@@ -5,19 +5,22 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/container_hash//boost_container_hash
+    /boost/core//boost_core
+    /boost/throw_exception//boost_throw_exception ;
+
 project /boost/type_index
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/container_hash//boost_container_hash
-        <library>/boost/core//boost_core
-        <library>/boost/throw_exception//boost_throw_exception
         <include>include
     ;
 
 explicit
-    [ alias boost_type_index ]
+    [ alias boost_type_index : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_type_index test ]
     ;
 
 call-if : boost-library type_index
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -12,10 +12,7 @@ project /boost/type_index
         <library>/boost/config//boost_config
         <library>/boost/container_hash//boost_container_hash
         <library>/boost/core//boost_core
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/static_assert//boost_static_assert
         <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -7,13 +7,13 @@ import project ;
 
 project /boost/type_index
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/container_hash//boost_container_hash
-        <source>/boost/core//boost_core
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/container_hash//boost_container_hash
+        <library>/boost/core//boost_core
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -9,9 +9,9 @@ import doxygen ;
 
 doxygen autodoc
    :
-      [ glob ../../../boost/type_index.hpp ]
-      [ glob ../../../boost/type_index/*.hpp ]
-      [ glob ../../../boost/type_index/runtime_cast/*.hpp ]
+      [ glob ../include/boost/type_index.hpp ]
+      [ glob ../include/boost/type_index/*.hpp ]
+      [ glob ../include/boost/type_index/runtime_cast/*.hpp ]
    :
         <doxygen:param>EXTRACT_ALL=NO
         <doxygen:param>HIDE_UNDOC_MEMBERS=YES

--- a/examples/user_defined_typeinfo.cpp
+++ b/examples/user_defined_typeinfo.cpp
@@ -14,7 +14,7 @@
 */
 
 // BOOST_TYPE_INDEX_USER_TYPEINDEX must be defined *BEFORE* first inclusion of <boost/type_index.hpp>
-#define BOOST_TYPE_INDEX_USER_TYPEINDEX <boost/../libs/type_index/examples/user_defined_typeinfo.hpp>
+#define BOOST_TYPE_INDEX_USER_TYPEINDEX <user_defined_typeinfo.hpp>
 #include <boost/type_index.hpp>
 //] [/type_index_my_type_index_worldwide_macro]
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -15,6 +15,7 @@ import os ;
 project
     : source-location .
     : requirements
+        <library>/boost/type_index//boost_type_index
         [ requires cxx11_rvalue_references ]
     ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -4,11 +4,12 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 import testing ;
 import feature ;
 import os ;
-
-import ../../config/checks/config : requires ;
 
 project
     : source-location .
@@ -47,10 +48,10 @@ exe testing_crossmodule_anonymous_no_rtti : testing_crossmodule_anonymous.cpp te
 
 test-suite type_index
   : 
-    [ run type_index_test.cpp ]
-    [ run type_index_runtime_cast_test.cpp ]
+    [ run type_index_test.cpp /boost/lexical_cast//boost_lexical_cast ]
+    [ run type_index_runtime_cast_test.cpp /boost/smart_ptr//boost_smart_ptr ]
     [ run type_index_constexpr_test.cpp ]
-    [ run type_index_test.cpp : : : <rtti>off $(norttidefines) : type_index_test_no_rtti ]
+    [ run type_index_test.cpp /boost/lexical_cast//boost_lexical_cast : : : <rtti>off $(norttidefines) : type_index_test_no_rtti ]
     [ run ctti_print_name.cpp : : : <test-info>always_show_run_output ]
     [ run testing_crossmodule.cpp test_lib_rtti ]
     [ run testing_crossmodule.cpp test_lib_nortti : : : <rtti>off $(norttidefines) : testing_crossmodule_no_rtti ]
@@ -77,13 +78,13 @@ test-suite type_index
 for local p in [ glob ../examples/*.cpp ]
 {
     # RTTI on
-    type_index += [ run $(p) ] ;
+    type_index += [ run $(p) /boost/unordered//boost_unordered : : : <include>../examples ] ;
 
     # RTTI off
     local target_name = $(p[1]:B)_no_rtti ;
     if $(target_name) != "table_of_names_no_rtti"
     {
-        type_index += [ run $(p) : : : <rtti>off $(norttidefines) : $(target_name) ] ;
+        type_index += [ run $(p) /boost/unordered//boost_unordered : : : <include>../examples <rtti>off $(norttidefines) : $(target_name) ] ;
     }
 }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,6 +6,7 @@
 
 require-b2 5.0.1 ;
 import-search /boost/config/checks ;
+import-search /boost/config/checks ;
 import config : requires ;
 import testing ;
 import feature ;
@@ -47,7 +48,7 @@ lib test_lib_rtti_compat : test_lib_rtti_compat-obj : <link>shared $(nortti) $(c
 exe testing_crossmodule_anonymous_no_rtti : testing_crossmodule_anonymous.cpp test_lib_anonymous_nortti : <rtti>off $(norttidefines) ;
 
 test-suite type_index
-  : 
+  :
     [ run type_index_test.cpp /boost/lexical_cast//boost_lexical_cast ]
     [ run type_index_runtime_cast_test.cpp /boost/smart_ptr//boost_smart_ptr ]
     [ run type_index_constexpr_test.cpp ]
@@ -66,15 +67,15 @@ test-suite type_index
     # Mixing RTTI on and off
 
     # MSVC sometimes overrides the /GR-, without `detect_missmatch` this test may link.
-    # TODO: Disabled on MSVC. Enable again when there'll be an understanding of how to write this test correctly wor MSVC. 
+    # TODO: Disabled on MSVC. Enable again when there'll be an understanding of how to write this test correctly wor MSVC.
     [ link-fail testing_crossmodule.cpp test_lib_rtti : $(nortti)  <toolset>msvc:<build>no : link_fail_nortti_rtti ]
     [ link-fail testing_crossmodule.cpp test_lib_nortti : <toolset>msvc:<build>no : link_fail_rtti_nortti ]
 
     [ run testing_crossmodule.cpp test_lib_rtti_compat : : : $(nortti) $(compat) : testing_crossmodule_nortti_rtti_compat ]
     [ run testing_crossmodule.cpp test_lib_nortti_compat : : : $(compat) : testing_crossmodule_rtti_nortti_compat ]
   ;
-  
-# Assuring that examples compile and run. Adding sources from `examples` directory to the `type_index` test suite. 
+
+# Assuring that examples compile and run. Adding sources from `examples` directory to the `type_index` test suite.
 for local p in [ glob ../examples/*.cpp ]
 {
     # RTTI on


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.